### PR TITLE
#77 replace png with svg logo

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -1,5 +1,5 @@
 project:
-  logo_url: "https://raw.githubusercontent.com/cncf/artwork/53f1179f7950f27e330fce4e983304de59811b52/linkerd/icon/color/linkerd-icon-color.png"
+  logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/linkerd/icon/color/linkerd-icon-color.svg?sanitize=true"
   display_name: Linkerd
   sub_title: Service Mesh
   project_url: "https://github.com/linkerd/linkerd"


### PR DESCRIPTION
crosscloudci/ci-dashboard#77

Changes made: 
  logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/linkerd/icon/color/linkerd-icon-color.svg?sanitize=true"