### PR TITLE
update logo w/ project directory URL

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -1,5 +1,5 @@
 project:
-  logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/linkerd/icon/color/linkerd-icon-color.svg?sanitize=true"
+  logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/projects/linkerd/icon/color/linkerd-icon-color.svg?sanitize=true"
   display_name: Linkerd
   sub_title: Service Mesh
   project_url: "https://github.com/linkerd/linkerd"


### PR DESCRIPTION
crosscloudci/ci-dashboard#90

Changes made: add /projects/ to URL

logo_url: 

https://raw.githubusercontent.com/cncf/artwork/master/projects/linkerd/icon/color/linkerd-icon-color.svg