### PR TITLE
Enable Linkerd v1.6.4 on production 

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -3,5 +3,5 @@ project:
   display_name: Linkerd
   sub_title: Service Mesh
   project_url: "https://github.com/linkerd/linkerd"
-  stable_ref: "1.6.3"
+  stable_ref: "1.6.4"
   head_ref: "master"


### PR DESCRIPTION
- Enable Linkerd v1.6.4 on production (cncf.ci) via linkerd-configuration production branch
- crosscloudci/crosscloudci#159